### PR TITLE
Truncate floating point element coordinates

### DIFF
--- a/lib/watir/extensions/element/screenshot.rb
+++ b/lib/watir/extensions/element/screenshot.rb
@@ -8,7 +8,7 @@ module Watir
       begin
         browser.screenshot.save(file)
         image = ChunkyPNG::Image.from_file(file)
-        image.crop!(wd.location.x + 1, wd.location.y + 1, wd.size.width, wd.size.height)
+        image.crop!(wd.location.x.to_i + 1, wd.location.y.to_i + 1, wd.size.width, wd.size.height)
         image.save(dest)
       ensure 
         file.unlink 

--- a/lib/watir/extensions/element/screenshot/version.rb
+++ b/lib/watir/extensions/element/screenshot/version.rb
@@ -2,7 +2,7 @@ module Watir
   module Extensions
     module Element
       module Screenshot
-        VERSION = "0.0.2"
+        VERSION = "0.0.3"
       end
     end
   end


### PR DESCRIPTION
fixes https://github.com/ansoni/watir-extensions-element-screenshot/issues/2
