### PR TITLE
Add saving now optional, Fix crop! error for element out of viewport

### DIFF
--- a/lib/watir/extensions/element/screenshot.rb
+++ b/lib/watir/extensions/element/screenshot.rb
@@ -3,16 +3,38 @@ require 'chunky_png'
 
 module Watir
   class Element
-    def screenshot(dest)
-      file = Tempfile.new('sc')
-      begin
-        browser.screenshot.save(file)
-        image = ChunkyPNG::Image.from_file(file)
-        image.crop!(wd.location.x.to_i + 1, wd.location.y.to_i + 1, wd.size.width, wd.size.height)
-        image.save(dest)
-      ensure 
-        file.unlink 
-      end
+    # Takes screenshot of element and optionally saves it.
+    #
+    # @param [String] dest File destination if the user chooses
+    #   to save the screenshot.
+    # @return [ChunkyPNG::Image] Returns element screenshot as the instance
+    #   of ChunkyPNG::Image.
+    def screenshot(dest = nil)
+      viewpoer_pos_x = browser.execute_script('return window.pageXOffset;')
+      viewpoer_pos_y = browser.execute_script('return window.pageYOffset;')
+
+      image = ChunkyPNG::Image.from_blob(browser.screenshot.png)
+
+      element_pos_x = (viewpoer_pos_x - wd.location.x).abs
+      element_pos_y = (viewpoer_pos_y - wd.location.y).abs
+      image_crop_width = if element_pos_x + wd.size.width > image.width
+                           image.width - element_pos_x
+                         else
+                           wd.size.width
+                         end
+      image_crop_height = if element_pos_y + wd.size.height > image.height
+                            image.height - element_pos_y
+                          else
+                            wd.size.height
+                          end
+
+      image.crop!(element_pos_x,
+                  element_pos_y,
+                  image_crop_width,
+                  image_crop_height)
+
+      image.save(dest) unless dest.nil?
+      image
     end
   end
 end


### PR DESCRIPTION
Added option to save the screenshot or just to recieve it back as
ChunkyPNG::Image so users are now able to work with the image in
their automated test.

Fixed error of crop! when the element was too big for the viewport
or when it was somewhere in the middle of the page.

Know problem - You still need to scroll to the element and it needs
to be visible on the page.